### PR TITLE
Manage timezone for filters

### DIFF
--- a/app/code/community/Mbiz/Reports/Block/Adminhtml/Sales/Journal/Result.php
+++ b/app/code/community/Mbiz/Reports/Block/Adminhtml/Sales/Journal/Result.php
@@ -92,7 +92,7 @@ class Mbiz_Reports_Block_Adminhtml_Sales_Journal_Result extends Mage_Adminhtml_B
             $title = Mage::helper('mbiz_reports')->__(
                 "From %s to %s",
                 $this->getRequest()->getFromDate()->toString(Zend_Date::DATE_LONG),
-                $this->getRequest()->getTODate()->toString(Zend_Date::DATE_LONG)
+                $this->getRequest()->getToDate()->toString(Zend_Date::DATE_LONG)
             );
         }
         return $title;

--- a/app/code/community/Mbiz/Reports/Model/Sales/Journal/Result/Abstract.php
+++ b/app/code/community/Mbiz/Reports/Model/Sales/Journal/Result/Abstract.php
@@ -33,6 +33,9 @@ abstract class Mbiz_Reports_Model_Sales_Journal_Result_Abstract extends Varien_O
         // The period
         list($from, $to) = $request->getPeriod();
 
+        $from = $this->convertToGmt($from->toString('y-MM-dd') . '00:00:00');
+        $to = $this->convertToGmt($to->toString('y-MM-dd') . '23:59:59');
+
         return $this->_load($request, $from, $to);
     }
 
@@ -55,6 +58,23 @@ abstract class Mbiz_Reports_Model_Sales_Journal_Result_Abstract extends Varien_O
         /* @var $res Mage_Core_Model_Resource */
         $res = Mage::getSingleton('core/resource');
         return $res->getTableName($alias);
+    }
+
+    /**
+     * Convert the given string in format `Y-m-d H:i:s` to a date in GMT
+     *
+     * @param string $datetime
+     * @return Zend_Date
+     * @throws Zend_Date_Exception
+     */
+    public function convertToGmt($datetime)
+    {
+        return Mage::app()->getLocale()->date(
+            Varien_Date::toTimestamp(Mage::getModel('core/date')->gmtDate('Y-m-d H:i:s', $datetime)),
+            null,
+            null,
+            true
+        )->setTimezone('UTC');
     }
 
     /**

--- a/app/code/community/Mbiz/Reports/Model/Sales/Journal/Result/CreditMemo.php
+++ b/app/code/community/Mbiz/Reports/Model/Sales/Journal/Result/CreditMemo.php
@@ -32,8 +32,8 @@ class MBiz_Reports_Model_Sales_Journal_Result_CreditMemo extends Mbiz_Reports_Mo
                 'subtotal' => 'SUM(ROUND(memo.subtotal, 2))',
                 'total' => 'SUM(ROUND(memo.grand_total, 2))',
             ])
-            ->where("DATE(memo.created_at) >= ?", $from->toString('y-MM-dd'))
-            ->where("DATE(memo.created_at) <= ?", $to->toString('y-MM-dd'))
+            ->where("memo.created_at >= ?", $from->toString('y-MM-dd HH:mm:ss'))
+            ->where("memo.created_at <= ?", $to->toString('y-MM-dd HH:mm:ss'))
         ;
 
         $results = $select->query()->fetch();

--- a/app/code/community/Mbiz/Reports/Model/Sales/Journal/Result/Payment/Method.php
+++ b/app/code/community/Mbiz/Reports/Model/Sales/Journal/Result/Payment/Method.php
@@ -38,8 +38,8 @@ class Mbiz_Reports_Model_Sales_Journal_Result_Payment_Method extends Mbiz_Report
                 'tax'      => 'SUM(ROUND(IFNULL(invoice.base_tax_amount, 0), 2))',
                 'total'    => 'SUM(ROUND(IFNULL(invoice.base_grand_total, 0), 2))',
             ])
-            ->where("DATE(invoice.created_at) >= ?", $from->toString('y-MM-dd'))
-            ->where("DATE(invoice.created_at) <= ?", $to->toString('y-MM-dd'))
+            ->where("invoice.created_at >= ?", $from->toString('y-MM-dd HH:mm:ss'))
+            ->where("invoice.created_at <= ?", $to->toString('y-MM-dd HH:mm:ss'))
 
             // Join payment
             ->joinRight([

--- a/app/code/community/Mbiz/Reports/Model/Sales/Journal/Result/Summary.php
+++ b/app/code/community/Mbiz/Reports/Model/Sales/Journal/Result/Summary.php
@@ -34,8 +34,8 @@ class Mbiz_Reports_Model_Sales_Journal_Result_Summary extends Mbiz_Reports_Model
                 'tax'      => 'SUM(ROUND(invoice.base_tax_amount, 2))',
                 'total'    => 'SUM(ROUND(invoice.grand_total, 2))',
             ])
-            ->where("DATE(invoice.created_at) >= ?", $from->toString('y-MM-dd'))
-            ->where("DATE(invoice.created_at) <= ?", $to->toString('y-MM-dd'))
+            ->where("invoice.created_at >= ?", $from->toString('y-MM-dd HH:mm:ss'))
+            ->where("invoice.created_at <= ?", $to->toString('y-MM-dd HH:mm:ss'))
         ;
 
         $results = $select->query()->fetch();

--- a/app/code/community/Mbiz/Reports/Model/Sales/Journal/Result/SummaryAvg.php
+++ b/app/code/community/Mbiz/Reports/Model/Sales/Journal/Result/SummaryAvg.php
@@ -35,8 +35,8 @@ class Mbiz_Reports_Model_Sales_Journal_Result_SummaryAvg extends Mbiz_Reports_Mo
                 'total' => 'SUM(ROUND(invoice.grand_total, 2)) / COUNT(*)',
                 'avg' => 'SUM(ROUND(invoice.base_subtotal, 2) + ROUND(invoice.base_discount_amount, 2) + ROUND(invoice.shipping_amount, 2)) / COUNT(*)',
             ])
-            ->where("DATE(invoice.created_at) >= ?", $from->toString('y-MM-dd'))
-            ->where("DATE(invoice.created_at) <= ?", $to->toString('y-MM-dd'))
+            ->where("invoice.created_at >= ?", $from->toString('y-MM-dd HH:mm:ss'))
+            ->where("invoice.created_at <= ?", $to->toString('y-MM-dd HH:mm:ss'))
         ;
 
         $results = $select->query()->fetch();

--- a/app/code/community/Mbiz/Reports/Model/Sales/Journal/Result/Tax/Rate.php
+++ b/app/code/community/Mbiz/Reports/Model/Sales/Journal/Result/Tax/Rate.php
@@ -44,8 +44,8 @@ class Mbiz_Reports_Model_Sales_Journal_Result_Tax_Rate extends Mbiz_Reports_Mode
                 "amount" => "SUM(ROUND(IFNULL(invoice.base_tax_amount, 0), 2))",
                 'invoices_total'    => "SUM(ROUND(IFNULL(invoice.base_grand_total, 0), 2))",
             ])
-            ->where("DATE(invoice.created_at) >= ?", $from->toString('y-MM-dd'))
-            ->where("DATE(invoice.created_at) <= ?", $to->toString('y-MM-dd'))
+            ->where("invoice.created_at >= ?", $from->toString('y-MM-dd HH:mm:ss'))
+            ->where("invoice.created_at <= ?", $to->toString('y-MM-dd HH:mm:ss'))
             ->group("tax.code")
         ;
 
@@ -68,8 +68,8 @@ class Mbiz_Reports_Model_Sales_Journal_Result_Tax_Rate extends Mbiz_Reports_Mode
                 "amount" => new Zend_Db_Expr("0.0"),
                 'invoices_total'    => "SUM(ROUND(IFNULL(invoice.base_grand_total, 0), 2))",
             ])
-            ->where("DATE(invoice.created_at) >= ?", $from->toString('y-MM-dd'))
-            ->where("DATE(invoice.created_at) <= ?", $to->toString('y-MM-dd'))
+            ->where("invoice.created_at >= ?", $from->toString('y-MM-dd HH:mm:ss'))
+            ->where("invoice.created_at <= ?", $to->toString('y-MM-dd HH:mm:ss'))
             ->where("invoice.order_id NOT IN ?", $selectOrdersId)
         ;
 


### PR DESCRIPTION
I have an invoice is created at `2020-04-06 23:34:11` GMT.

<img width="165" alt="image" src="https://user-images.githubusercontent.com/11380627/78696883-51f20d80-7900-11ea-8c9a-3e712a4e9545.png">

In backoffice, I am in GMT+2. 
So if I search for orders from `2020-04-07` this invoice must be listed, but it's not : 

<img width="1650" alt="image" src="https://user-images.githubusercontent.com/11380627/78697150-a8f7e280-7900-11ea-8cf1-e7c49a1b0953.png">

With this PR, invoices like this will be listed correctly : 
<img width="1656" alt="image" src="https://user-images.githubusercontent.com/11380627/78697196-b6ad6800-7900-11ea-993b-fa2dfc28eee0.png">


